### PR TITLE
For appending string use << instead of +=. It has huge performance affec...

### DIFF
--- a/lib/cheetah.rb
+++ b/lib/cheetah.rb
@@ -208,7 +208,7 @@ module Cheetah
 
         ios_read.each do |pipe|
           begin
-            outputs[pipe] += pipe.readpartial(4096)
+            outputs[pipe] << pipe.readpartial(4096)
           rescue EOFError
             pipe.close
           end


### PR DESCRIPTION
...t on bigger outputs and is independent on string size ( at least on ruby 1.8)

Here is measure I do on my ruby 1.8 ( I don't exactly measure for which size of output it start to become really problematic issue, but I think that so simple change doesn't deserve it ):

$ cat ruby-perf.rb
s = ""
1.upto 1000000 do
  s += " "
end

$ time ruby ruby-perf.rb 

real    5m19.034s
user    4m41.915s
sys 0m36.324s

$ cat ruby-perf2.rb
s = ""
1.upto 1000000 do
  s << " "
end

$ time ruby ruby-perf2.rb 

real    0m0.340s
user    0m0.334s
sys 0m0.005s
