### PR TITLE
Include at least first line of stderr to exception. It helps in many cas...

### DIFF
--- a/lib/cheetah.rb
+++ b/lib/cheetah.rb
@@ -249,7 +249,8 @@ module Cheetah
           raise ExecutionFailed.new(command, args, status, stdout, stderr,
             "Execution of command #{command.inspect} " +
             "with #{describe_args(args)} " +
-            "failed with status #{status.exitstatus}.")
+            "failed with status #{status.exitstatus}." +
+            "First line of error output: #{stderr.split("\n").first}")
         end
       ensure
         if logger


### PR DESCRIPTION
...e and don't increase much size of message.

Use case is all uncaught exception. exitstatus and parameters are useless for reason detection.
