### PR TITLE
require stringio as it is used in code

### DIFF
--- a/lib/cheetah.rb
+++ b/lib/cheetah.rb
@@ -1,5 +1,6 @@
 require "logger"
 require "shellwords"
+require "stringio"
 
 # A simple library for executing external commands safely and conveniently.
 #


### PR DESCRIPTION
To test that old behavior is broken just try

```
irb
  require "cheetah"
  Cheetah.run "ps"
```
