### PR TITLE
converts each argument to a string using `#to_s`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ To run a command, just specify it together with its arguments:
 ```ruby
 Cheetah.run("tar", "xzf", "foo.tar.gz")
 ```
+
+Cheetah converts each argument to a string using `#to_s`.
+
 ### Passing Input
 
 Using the `:stdin` option you can pass a string to command's standard input:

--- a/lib/cheetah.rb
+++ b/lib/cheetah.rb
@@ -380,7 +380,12 @@ module Cheetah
       # The following code ensures that the result consistently (in all three
       # cases) contains an array of arrays specifying commands and their
       # arguments.
-      args.all? { |a| a.is_a?(Array) } ? args : [args]
+      pipe = args.all? { |a| a.is_a?(Array) } ? args : [args]
+      pipe.map do |argv|
+        argv.map do |arg|
+          arg.to_s
+        end
+      end
     end
 
     def build_recorder(options)

--- a/spec/cheetah_spec.rb
+++ b/spec/cheetah_spec.rb
@@ -166,6 +166,13 @@ describe Cheetah do
         command = create_command("touch #@tmp_dir/touched", :name => "foo < bar > baz | qux")
         lambda { Cheetah.run(command) }.should touch("#@tmp_dir/touched")
       end
+
+      it "converts params into strings" do
+        command = create_command("echo -n \"$@\" >> #@tmp_dir/args")
+        lambda {
+          Cheetah.run([command, 0, 1, [10, 20]])
+        }.should write("0 1 [10, 20]").into("#@tmp_dir/args")
+      end
     end
 
     describe "running piped commands" do


### PR DESCRIPTION
This is mostly useful when using number literals
(FixNum instances):

    Cheetah.run 'test', 0, '-lt', number