### PR TITLE
Add example how to get exit status

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ rescue Cheetah::ExecutionFailed => e
   puts e.message
   puts "Standard output: #{e.stdout}"
   puts "Error ouptut:    #{e.stderr}"
+  puts "Exit status:     #{e.status.exitstatus}"
 end
 ```
 ### Logging


### PR DESCRIPTION
Getting the exit status of the executed command is non-trivial, so add an example to the README.